### PR TITLE
Transitive header dependencies with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,7 @@ set (CXX_COMMON_FLAGS "-std=c++14 -Wall -Wextra")
 set (CMAKE_CXX_FLAGS_DEBUG "${CXX_COMMON_FLAGS} -O0 -g")
 set (CMAKE_CXX_FLAGS_RELEASE "${CXX_COMMON_FLAGS} -O2")
 
-include_directories ("${PROJECT_SOURCE_DIR}/include")
-include_directories ("${PROJECT_SOURCE_DIR}/include/util")
-
 find_package(Boost COMPONENTS regex system thread unit_test_framework REQUIRED)
-include_directories(${Boost_INCLUDE_DIRS})
 
 add_subdirectory (lib)
 add_subdirectory (ut)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,2 +1,3 @@
 file (GLOB sources "../src/util/*.cpp")
 add_library(cpp-util ${sources})
+target_include_directories(cpp-util PUBLIC ../include ../include/util)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,3 +1,4 @@
 file (GLOB sources "../src/util/*.cpp")
 add_library(cpp-util ${sources})
 target_include_directories(cpp-util PUBLIC ../include ../include/util)
+target_include_directories(cpp-util PUBLIC ${Boost_INCLUDE_DIRS})


### PR DESCRIPTION
Now cmake can automatically add the header dependencies whenever we link with cpp-util with `target_link_libraries(A cpp-util)`.
http://stackoverflow.com/questions/26243169/cmake-target-include-directories-meaning-of-scope
